### PR TITLE
Remove custom readonly message functionality

### DIFF
--- a/src/components/CodeEditor/CodeEditor.js
+++ b/src/components/CodeEditor/CodeEditor.js
@@ -144,7 +144,6 @@ export const CodeEditor = ({
   themeDark = defaultThemeDark,
   runEvalscriptButtonText = "Run evalscript",
   runningEvalscriptButtonText = "Running evalscript",
-  readOnlyMessage = "Editor is in read only mode"
 }) => {
 
 
@@ -237,10 +236,6 @@ export const CodeEditor = ({
       });
 
 
-      const messageContribution = editorRef.current.getContribution('editor.contrib.messageController');
-      editorRef.current.onDidAttemptReadOnlyEdit(() => {
-        messageContribution.showMessage(readOnlyMessage, editorRef.current.getPosition());
-      });
 
       monacoRef.current = monaco;
       editorRef.current.onDidChangeModelContent(() => {

--- a/src/components/Wrapper/Wrapper.jsx
+++ b/src/components/Wrapper/Wrapper.jsx
@@ -156,7 +156,6 @@ export default function Wrapper() {
           editorTheme="dark"
           portalId="root"
           isReadOnly={isReadOnly}
-          readOnlyMessage={`Editor is in read only mode. Untick "Load script from URL" to enable it again.`}
         />
         <h1 style={{ color: "white" }}>
           Wrapper to simulate parent div in apps like EOB and RB


### PR DESCRIPTION
Agreed together with team6 that it shouldn't be possible to interact with the readonly editor at all.

- Removes the popup box with message. 