### PR TITLE
Use correct color theme in the custom script editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel-hub/evalscript-code-editor",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "description": "",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/components/CodeEditor/editor-themes/themesCdasBrowser.jsx
+++ b/src/components/CodeEditor/editor-themes/themesCdasBrowser.jsx
@@ -20,9 +20,9 @@ export const themeCdasBrowserLight = {
     colorBg500: "#ffffff",
     colorBg600: "#f4f4f4",
     colorUI500: "#363636",
-    colorPrimary500: "#585867",
-    colorPrimary600: "#6d7300",
-    colorText500: "#101119",
+    colorPrimary500: "#004494",
+    colorPrimary600: "#00397c",
+    colorText500: "#fff",
     switchHeight: "20px",
   },
 };


### PR DESCRIPTION
Closes: https://git.sinergise.com/team-6/eobrowser3/-/issues/937

**_List of implemented tasks on this MR_**
- Use correct colour theme in the custom script editor