### PR TITLE
allow running evalscript action on ctrl+enter shortcut

### DIFF
--- a/src/components/CodeEditor/CodeEditor.js
+++ b/src/components/CodeEditor/CodeEditor.js
@@ -219,6 +219,7 @@ export const CodeEditor = ({
 
       if (runEvalscriptOnShortcut && onRunEvalscriptClick) {
         editorRef.current.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+          setShouldTriggerRunEvalscriptAnimation(true);
           onRunEvalscriptClick(editorRef.current.getValue());
         });
       }

--- a/src/components/CodeEditor/CodeEditor.js
+++ b/src/components/CodeEditor/CodeEditor.js
@@ -140,6 +140,7 @@ export const CodeEditor = ({
   runEvalscriptButtonText = "Run evalscript",
   runningEvalscriptButtonText = "Running evalscript",
   readOnlyMessage = "Editor is in read only mode",
+  runEvalscriptOnShortcut = false,
 }) => {
   const monacoEditorDOMRef = useRef();
   const monacoRef = useRef();
@@ -215,6 +216,12 @@ export const CodeEditor = ({
           alwaysConsumeMouseWheel: isDocked ? false : true,
         },
       });
+
+      if (runEvalscriptOnShortcut && onRunEvalscriptClick) {
+        editorRef.current.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+          onRunEvalscriptClick(editorRef.current.getValue());
+        });
+      }
 
       const messageContribution = editorRef.current.getContribution("editor.contrib.messageController");
       editorRef.current.onDidAttemptReadOnlyEdit(() => {

--- a/src/components/Wrapper/Wrapper.jsx
+++ b/src/components/Wrapper/Wrapper.jsx
@@ -155,6 +155,8 @@ export default function Wrapper() {
           onChange={(code) => setEvalscript(code)}
           editorTheme="dark"
           portalId="root"
+          onRunEvalscriptClick={() => console.log("running function from shortcut! Ctrl+Enter")}
+          runEvalscriptOnShortcut
           isReadOnly={isReadOnly}
           readOnlyMessage={`Editor is in read only mode. Untick "Load script from URL" to enable it again.`}
         />


### PR DESCRIPTION
Adds a command using Ctrl/Cmd+Enter to run the prop action onRunEvalscriptClick if `runEvalscriptOnShortcut` is passed as true.